### PR TITLE
Support for "ref pointer" as arg in function calls

### DIFF
--- a/tests/alientest.c
+++ b/tests/alientest.c
@@ -197,6 +197,13 @@ EXPORT(int) getSPAMANDEGGS(EGG **eggs)
 	return 1;
 }
 
+EXPORT(int) getSPAMREF(void **ptr)
+{
+	*ptr = (void *) &my_spams[0];
+	return 1;
+}
+
+
 typedef struct tagpoint {
 	int x;
 	int y;

--- a/tests/test_alien.lua
+++ b/tests/test_alien.lua
@@ -74,6 +74,20 @@ end
 
 do
   io.write(".")
+  local spam = alien.defstruct{
+    { "name", "string" },
+    { "value", "string" },
+  }
+  local f = dll.getSPAMREF
+  f:types("int", "ref pointer")
+  local _, pointer = f(nil)
+  local spam1 = spam:new(pointer)
+  assert(spam1.name == "name1")
+  assert(spam1.value == "value1")
+end
+
+do
+  io.write(".")
   local integrate = dll.integrate
   integrate:types("double", "double", "double", "callback", "long")
   local function func(x)


### PR DESCRIPTION
C function interface 

EXPORT(int) getSPAMREF(void **ptr)

handling by alien

f:types("int", "ref pointer")

Loot at test_alien.lua for completed test.
