### PR TITLE
Make buffers reallocable

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -13,9 +13,8 @@ LIBFFI_OBJS=libffi\win32\ffi.obj libffi\win32\prep_cif.obj libffi\win32\types.ob
 {libffi\win32}.c{libffi\win32}.obj:
 	cl /c /MD /Fo$@ $(CFLAGS) /D_MSC_VER /DX86_WIN32 $<
 
-all: src\alien\core.dll src\alien\struct.dll tests\alientest.dll
+all: src\alien\core.dll tests\alientest.dll
 	IF EXIST src\alien\core.dll.manifest del src\alien\core.dll.manifest
-	IF EXIST src\alien\struct.dll.manifest del src\alien\struct.dll.manifest
 	IF EXIST tests\alientest.dll.manifest del tests\alientest.dll.manifest
 
 libffi\win32\ffi.lib: $(LIBFFI_OBJS)
@@ -24,10 +23,6 @@ libffi\win32\ffi.lib: $(LIBFFI_OBJS)
 src\alien\core.dll: src\alien\core.obj libffi\win32\ffi.lib
 	link /dll /out:src\alien\core.dll /def:src\alien\core.def src\alien\core.obj $(LIB_OPTION) libffi\win32\ffi.lib
 	IF EXIST src\alien\core.dll.manifest mt -manifest src\alien\core.dll.manifest -outputresource:src\alien\core.dll;2
-
-src\alien\struct.dll: src\alien\struct.obj 
-	link /dll /out:src\alien\struct.dll /def:src\alien\struct.def $(LIB_OPTION) src\alien\struct.obj
-	IF EXIST src\alien\struct.dll.manifest mt -manifest src\alien\struct.dll.manifest -outputresource:src\alien\struct.dll;2
 
 tests\alientest.dll:
 	cl /c /MD $(CFLAGS) /Fotests\alientest.obj tests\alientest.c
@@ -38,7 +33,6 @@ install:
 	IF NOT EXIST "$(LUA_LIBDIR)\alien" mkdir "$(LUA_LIBDIR)\alien"
 	copy src\alien\core.dll "$(LUA_LIBDIR)\alien"
 	IF NOT EXIST "$(LUA_LIBDIR)\alien" mkdir "$(LUA_LIBDIR)\alien"
-	copy src\alien\struct.dll "$(LUA_LIBDIR)\alien"
 	copy src\alien.lua "$(LUA_DIR)\"
 	copy src\constants "$(BIN_DIR)\"
 	xcopy /E /S tests "$(PREFIX)\tests\"

--- a/Makefile.win64
+++ b/Makefile.win64
@@ -13,9 +13,8 @@ LIBFFI_OBJS=libffi\win32\ffi.obj libffi\win32\prep_cif.obj libffi\win32\types.ob
 {libffi\win32}.c{libffi\win32}.obj:
 	cl /c /MD /Fo$@ $(CFLAGS) /D_MSC_VER /DX86_64 $<
 
-all: src\alien\core.dll src\alien\struct.dll tests\alientest.dll
+all: src\alien\core.dll tests\alientest.dll
 	IF EXIST src\alien\core.dll.manifest del src\alien\core.dll.manifest
-	IF EXIST src\alien\struct.dll.manifest del src\alien\struct.dll.manifest
 	IF EXIST tests\alientest.dll.manifest del tests\alientest.dll.manifest
 
 libffi\win32\ffi.lib: $(LIBFFI_OBJS)
@@ -28,10 +27,6 @@ src\alien\core.dll: src\alien\core.obj libffi\win32\ffi.lib
 	link /dll /out:src\alien\core.dll /def:src\alien\core.def src\alien\core.obj $(LIB_OPTION) libffi\win32\ffi.lib
 	IF EXIST src\alien\core.dll.manifest mt -manifest src\alien\core.dll.manifest -outputresource:src\alien\core.dll;2
 
-src\alien\struct.dll: src\alien\struct.obj 
-	link /dll /out:src\alien\struct.dll /def:src\alien\struct.def $(LIB_OPTION) src\alien\struct.obj
-	IF EXIST src\alien\struct.dll.manifest mt -manifest src\alien\struct.dll.manifest -outputresource:src\alien\struct.dll;2
-
 tests\alientest.dll:
 	cl /c /MD $(CFLAGS) /Fotests\alientest.obj tests\alientest.c
 	link /dll /out:tests\alientest.dll tests\alientest.obj $(LIB_OPTION)
@@ -41,7 +36,6 @@ install:
 	IF NOT EXIST "$(LUA_LIBDIR)\alien" mkdir "$(LUA_LIBDIR)\alien"
 	copy src\alien\core.dll "$(LUA_LIBDIR)\alien"
 	IF NOT EXIST "$(LUA_LIBDIR)\alien" mkdir "$(LUA_LIBDIR)\alien"
-	copy src\alien\struct.dll "$(LUA_LIBDIR)\alien"
 	copy src\alien.lua "$(LUA_DIR)\"
 	copy src\constants "$(BIN_DIR)\"
 	xcopy /E /S tests "$(PREFIX)\tests\"

--- a/doc/index.html
+++ b/doc/index.html
@@ -33,10 +33,7 @@ the test suite (<code>tests</code>) you can run the suite with:</p>
 <pre><code>lua -l luarocks.require test_alien.lua
 </code></pre>
 
-<p>Alien installs two modules, <code>alien</code> and <code>alien.struct</code>. The latter is a
-slightly modified version of Roberto Ierusalimschy&rsquo;s <a href="http://www.inf.puc-rio.br/~roberto/struct">struct
-library</a> that can unpack
-binary blobs (userdata) instead of just strings.</p>
+<p>Alien installs one module, <code>alien</code>.
 
 <h2>Basic Usage</h2>
 
@@ -166,6 +163,8 @@ You can also call <code>buf:len</code>, which calls <em>strlen</em> on the buffe
 
 <p>To get a pointer to a buffer, use <code>buf:topointer(offset)</code>; the argument is optional, defaulting to 1.</p>
 
+<p>You can reallocate a buffer using <code>buf:realloc(newsize)</code>. This uses the current Lua state's allocation function.</p>
+
 <p>An example of how to use a buffer:</p>
 
 <pre><code>&gt; gets = alien.default.gets
@@ -190,7 +189,8 @@ size (in bytes) of each element with <em>arr.size</em>. The underlying buffer is
 
 <p>You can access the i-th element with <em>arr[i]</em>, and set it with <em>arr[i] = val</em>. Type
 conversions are the same as with buffers, or function calls. Storing a string or userdata
-in an array pins it so it won&rsquo;t be collected while it is in the array.</p>
+in an array pins it so it won&rsquo;t be collected while it is in the array. You can resize an
+array too: <code>arr:realloc(newlen)</code> changes the length to <em>newlen</em>.</p>
 
 <p>For convenience <code>alien.array</code> also accepts two other forms: <code>alien.array(type, tab)</code> creates
 an array with the same length as <em>tab</em> and initializes it with its values;
@@ -217,7 +217,10 @@ for i, v in nums:ipairs() do print(v) end
 <h2>Structs</h2>
 
 <p>Alien also has basic support for declarative structs that is also implemented as a layer of sugar
-on the basic buffers. The <code>alien.defstruct(description)</code> function creates a struct type with the
+on the basic buffers. It uses a slightly modified version of Roberto Ierusalimschy&rsquo;s
+<a href="http://www.inf.puc-rio.br/~roberto/struct">struct library</a> that can unpack
+binary blobs (userdata) instead of just strings.
+The <code>alien.defstruct(description)</code> function creates a struct type with the
 given description, which is a list of pairs with the name and type of each field, where the type is any
 basic alien type (no structs inside structs yet). For example:</p>
 
@@ -275,7 +278,7 @@ a pointer to an array of four floats, the following code unpacks this array:</p>
 </code></pre>
 
 <p>Use these functions with extra care, as they don&rsquo;t make any safety
-checks. For more advanced unmarshaling use the <code>alien.struct.unpack</code>
+checks. For more advanced unmarshaling use the <code>alien.unpack</code>
 function.</p>
 
 <h2>Tags</h2>

--- a/src/alien.lua
+++ b/src/alien.lua
@@ -122,6 +122,11 @@ function array_methods:ipairs()
   return array_next, self, 0
 end
 
+function array_methods:realloc(newlen)
+  self.buffer:realloc(newlen * self.size)
+  self.length = newlen
+end
+
 local function array_get(arr, key)
   if type(key) == "number" then
     if key < 1 or key > arr.length then

--- a/src/alien/Makefile.am
+++ b/src/alien/Makefile.am
@@ -3,10 +3,10 @@
 AM_CPPFLAGS = $(LUA_INCLUDE)
 AM_CFLAGS = $(CFLAGS_STACK)
 
-pkglib_LTLIBRARIES = core.la struct.la
+pkglib_LTLIBRARIES = core.la
 
 core_la_SOURCES = core.c
 core_la_LDFLAGS = -module -avoid-version -lffi
 
-struct_la_SOURCES = struct.c
-struct_la_LDFLAGS = -module -avoid-version
+# This file is #included, so does not need to be compiled
+EXTRA_DIST = struct.c

--- a/src/alien/struct.c
+++ b/src/alien/struct.c
@@ -219,8 +219,8 @@ static int b_pack (lua_State *L) {
       }
       case 'p': {
         void *p;
-        luaL_argcheck(L, lua_isuserdata(L, arg) || lua_isnil(L, arg), arg, "userdata, light userdata, or nil required");
-        p = lua_touserdata(L, arg++);
+        luaL_argcheck(L, lua_isuserdata(L, arg) || lua_isnil(L, arg), arg, "userdata or nil required");
+        p = alien_touserdata(L, arg++);
         luaL_addlstring(&b, (char*)&p, size);
         break;
       }
@@ -328,7 +328,7 @@ static int b_unpack (lua_State *L) {
   size_t ld, pos;
   const char *data;
   if(lua_isuserdata(L, 2)) {
-    data = (const char*)lua_touserdata(L, 2);
+    data = alien_touserdata(L, 2);
     ld = (size_t)luaL_checkinteger(L, 3);
     pos = luaL_optint(L, 4, 1) - 1;
   } else {
@@ -401,30 +401,3 @@ static int b_unpack (lua_State *L) {
 }
 
 /* }====================================================== */
-
-
-
-static const luaL_Reg thislib[] = {
-  {"pack", b_pack},
-  {"unpack", b_unpack},
-  {"size", b_size},
-  {"offset", b_offset},
-  {NULL, NULL}
-};
-
-
-LUALIB_API int luaopen_alien_struct (lua_State *L) {
-  lua_getglobal(L, "alien");
-  if(lua_isnil(L, -1)) {
-    lua_newtable(L);
-    lua_pushvalue(L, -1);
-    lua_setglobal(L, "alien");
-  }
-  lua_newtable(L);
-  lua_pushvalue(L, -1);
-  lua_setfield(L, -3, "struct");
-  luaL_register(L, NULL, thislib);
-  return 1;
-}
-
-

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,6 @@ libalientest_la_SOURCES = alientest.c
 libalientest_la_LDFLAGS = -module -avoid-version
 
 check-local:
-	cp "$(abs_top_builddir)/src/alien/$(objdir)/"{core,struct}$(shrext) "$(abs_top_builddir)/src/alien/"
+	cp "$(abs_top_builddir)/src/alien/$(objdir)/"core$(shrext) "$(abs_top_builddir)/src/alien/"
 	$(LUA_ENV) $(LUA) test_alien.lua
-	rm -f "$(abs_top_builddir)/src/alien/{core,struct}$(shrext)"
+	rm -f "$(abs_top_builddir)/src/alien/core$(shrext)"

--- a/tests/test_alien.lua
+++ b/tests/test_alien.lua
@@ -1,5 +1,4 @@
 require "alien"
-require "alien.struct"
 
 local dll = alien.alientest
 
@@ -466,6 +465,29 @@ end
 
 do
   io.write(".")
+  local buf = alien.buffer(4)
+  buf:realloc(8)
+  assert(buf.size == 8)
+end
+
+io.write(".")
+for _, t in ipairs(types) do
+  local arr = alien.array(t, 4)
+  local size = arr.size
+  local newlen = 15
+  arr:realloc(newlen)
+  assert(size == arr.size)
+  assert(arr.length == newlen)
+  for i = 1, newlen do
+    arr[i] = i*2
+  end
+  for i = 1, newlen do
+    assert(arr[i] == i*2)
+  end
+end
+
+do
+  io.write(".")
   local rect = alien.defstruct{
     { "left", "long" },
     { "top", "long" },
@@ -536,8 +558,6 @@ end
 
 do
   io.write(".")
-   local struct = alien.struct
-
    local buf = alien.buffer('123456')
    assert(alien.buffer(buf:topointer(3)):tostring(3,2)=='456')
 
@@ -547,24 +567,24 @@ do
    local S = '>ipbph'
    local ba = alien.buffer('a\0')
    local bb = alien.buffer('b\0')
-   local s = struct.pack(S,1,ba,2,bb,3)
+   local s = alien.pack(S,1,ba,2,bb,3)
    local buf = alien.buffer(s)
-   local one,pba,two,pbb,three = struct.unpack(S,buf,struct.size(S))
+   local one,pba,two,pbb,three = alien.unpack(S,buf,alien.size(S))
    assert(one==1) assert(two==2) assert(three==3)
    assert(alien.buffer(pba):tostring()=='a')
    assert(alien.tostring(pbb)=='b')
 
-   local pbb,three = struct.unpack('>ph',buf,struct.size(S),struct.offset(S,4))
+   local pbb,three = alien.unpack('>ph',buf,alien.size(S),alien.offset(S,4))
    assert(alien.buffer(pbb):tostring()=='b')
    assert(three==3)
 
-   --buf:set(struct.offset(S,4),struct.pack('p',ba))
-   --assert(alien.buffer(struct.unpack('p',buf,struct.size(S),struct.offset(S,4))):tostring()=='a')
+   --buf:set(alien.offset(S,4),alien.pack('p',ba))
+   --assert(alien.buffer(alien.unpack('p',buf,alien.size(S),alien.offset(S,4))):tostring()=='a')
 
-   assert(struct.size('p')==alien.sizeof("pointer"))
-   assert(struct.offset(S,1)==1)
-   assert(struct.offset(S,4)==6+alien.sizeof("pointer"))
-   assert(struct.offset(S,alien.sizeof("pointer")+2)==struct.size(S)+1)
+   assert(alien.size('p')==alien.sizeof("pointer"))
+   assert(alien.offset(S,1)==1)
+   assert(alien.offset(S,4)==6+alien.sizeof("pointer"))
+   assert(alien.offset(S,alien.sizeof("pointer")+2)==alien.size(S)+1)
 end
 
 local maxushort = 2^(8*alien.sizeof("ushort"))-1


### PR DESCRIPTION
In order to make this possible, all buffers now have to be allocated
indirectly (because a userdata cannot be resized).

In order to make this work, the struct library had to be made aware of
buffers; the simplest way was to merge it into the core library.

All documentation and build system files (including Windows makefiles)
have been updated accordingly.

The name "realloc" has been chosen to emphasise the direct connection with the underlying Lua allocator function; in particular, supplying a length/size of zero frees the given array/buffer; however, I would be happy to change the name if you think "resize" is better, for example.
