### PR TITLE
rockspec: don't clobber environment flags.

### DIFF
--- a/rockspec/alien-0.5.2-1.rockspec
+++ b/rockspec/alien-0.5.2-1.rockspec
@@ -17,6 +17,6 @@ dependencies = {
 }
 build = {
   type = "command",
-  build_command = "LUA=$(LUA) CPPFLAGS=-I$(LUA_INCDIR) ./configure --prefix=$(PREFIX) --libdir=$(LIBDIR) --datadir=$(LUADIR)",
+  build_command = "./configure LUA=$(LUA) --prefix=$(PREFIX) --libdir=$(LIBDIR) --datadir=$(LUADIR)",
   install_command = "make install"
 }


### PR DESCRIPTION
- rockspec/alien-0.5.2-1.rockspec (build): It's more hygienic to
  put configure flags _after_ the configure invocation.
  Also, append to any existing CPPFLAGS passed in the build
  environment.

Since Mac OS Lion ships with a libffi missing the recent closure APIs required by alien, I have to pass the include and library paths for my self-installed libffi to luarocks, otherwise it won't build:

```
CC=gcc-4.2 CFLAGS=-I/usr/local/Cellar/libffi/3.0.11/lib/libffi-3.0.11/include LDFLAGS=-L/usr/local/Cellar/libffi/3.0.11/lib luarocks make rockspecs/alien-0.5.2-1.rockspec
```

This match makes that possible without having to build and install directly from source.

Note: CC=gcc-4.2 is the Snow Leopard compiler, because XCode on Lion uses llvm and clang which don't compile alien properly.  It is available with homebrew - `brew install apple-gcc-4.2`  This is probably something that should go in the alien README for future builders on Mac OS X Lion?
