### PR TITLE
configury: correct mismerged conflict resolution in Makefile.ams

### DIFF
--- a/src/alien/Makefile.am
+++ b/src/alien/Makefile.am
@@ -1,17 +1,7 @@
-pkglib_LTLIBRARIES += 		\
-	src/alien/core.la	\
-	src/alien/struct.la
+pkglib_LTLIBRARIES += src/alien/core.la
 
 src_alien_core_la_SOURCES = src/alien/core.c
 src_alien_core_la_LDFLAGS = -module -avoid-version -lffi
 
-src_alien_struct_la_SOURCES = src/alien/struct.c
-src_alien_struct_la_LDFLAGS = -module -avoid-version
-
-pkglib_LTLIBRARIES = core.la
-
-core_la_SOURCES = core.c
-core_la_LDFLAGS = -module -avoid-version -lffi
-
 # This file is #included, so does not need to be compiled
-EXTRA_DIST = struct.c
+EXTRA_DIST += struct.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,6 @@ tests_libalientest_la_SOURCES = tests/alientest.c
 tests_libalientest_la_LDFLAGS = -module -avoid-version
 
 check-local:
-	cp "$(abs_top_builddir)/src/alien/$(objdir)/"core$(shrext) "$(abs_top_builddir)/src/alien/"
-	$(LUA_ENV) $(LUA) test_alien.lua
-	rm -f "$(abs_top_builddir)/src/alien/core$(shrext)"
+	cp src/alien/$(objdir)/core$(shrext) src/alien/
+	cd tests && $(LUA_ENV) $(LUA) test_alien.lua
+	rm -f src/alien/core$(shrext)


### PR DESCRIPTION
- src/alien/Makefile.am: Remove duplicates.
  (EXTRA_DIST): Always apprnd for non-recursive builds.
- tests/Makefile.am (check-local): Adjust to run correctly from
  $top_builddir.

Alien master doesn't bootstrap on Unix without these changes.
