### PR TITLE
Fix. alien.buffer `__index` metamethod returns fields from global environment

### DIFF
--- a/src/alien.c
+++ b/src/alien.c
@@ -917,6 +917,8 @@ static int alien_buffer_new(lua_State *L) {
   ud = lua_newuserdata(L, sizeof(alien_Buffer));
   if (!ud)
     return luaL_error(L, "alien: cannot allocate buffer");
+  lua_newtable(L);
+  lua_setuservalue(L, -2);
   ud->p = p;
   ud->size = size;
   luaL_getmetatable(L, ALIEN_BUFFER_META);

--- a/tests/test_alien.lua
+++ b/tests/test_alien.lua
@@ -573,6 +573,7 @@ end
 do
   io.write(".")
    local buf = alien.buffer('123456')
+   assert(buf.tostring ~= _G.tostring)
    assert(alien.buffer(buf:topointer(3)):tostring(3,2)=='456')
 
    --buf:set(1,'123abc')


### PR DESCRIPTION
Close #35 